### PR TITLE
fix(ci): Make git add in workflow more robust

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
-          git add archive/ content/ raw.json curated.json social_posts.json longread_outline.json published_post_url.txt
+          git add .
           if ! git diff --staged --quiet; then
             git commit -m "feat(content): Add generated content from workflow run"
             git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }} HEAD:main


### PR DESCRIPTION
The weekly content generation workflow was failing with the error `fatal: pathspec 'archive/' did not match any files`.

This occurred because the `git add` command explicitly listed files and directories to be added, including `archive/`. The `archive/` directory is only created by the content generation script if there is old content to archive. On an initial run or after a cleanup, this directory doesn't exist, causing the `git add` command to fail.

This commit fixes the issue by changing the command to `git add .`, which stages all new and modified files. This is more robust and resilient to cases where specific files or directories are not created.