### PR TITLE
feat(workflow): Run weekly workflow every two weeks

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -28,6 +28,17 @@ jobs:
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.skip_content_generation != 'true')
     steps:
+      - name: Check if week is even
+        if: github.event_name == 'schedule'
+        run: |
+          week_number=$(date +%V)
+          if [ $((week_number % 2)) -ne 0 ]; then
+            echo "Skipping on odd week number: $week_number"
+            # Use exit code 78 to gracefully skip the job
+            exit 78
+          else
+            echo "Running on even week number: $week_number"
+          fi
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
The GitHub Actions workflow is scheduled to run weekly. This change modifies the workflow to run every two weeks.

This is achieved by adding a step at the beginning of the `generate-content` job that checks the current week number. If the week number is odd, the job is gracefully skipped. This effectively makes the workflow run only on even-numbered weeks.