### PR TITLE
feat: Display all posts on homepage

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,22 +5,20 @@
     </section>
     <section class="flex-ns flex-wrap justify-around mt5">
       {{ range where .Site.RegularPages "Section" "posts" }}
-        {{ if (strings.HasPrefix .File.BaseFileName "longread_") }}
-          <div class="relative w-100 w-30-l mb4 bg-white">
-            <div class="bg-white mb3 pa4 gray overflow-hidden">
-              {{with .CurrentSection.Title }}<span class="f6 db">{{ . }}</span>{{end}}
-              <h1 class="f3 near-black">
-                <a href="{{ .RelPermalink }}" class="link black dim">
-                  {{ .Title }}
-                </a>
-              </h1>
-              <div class="nested-links f5 lh-copy nested-copy-line-height">
-                {{ .Summary }}
-              </div>
-              <a href="{{.RelPermalink}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
+        <div class="relative w-100 w-30-l mb4 bg-white">
+          <div class="bg-white mb3 pa4 gray overflow-hidden">
+            {{with .CurrentSection.Title }}<span class="f6 db">{{ . }}</span>{{end}}
+            <h1 class="f3 near-black">
+              <a href="{{ .RelPermalink }}" class="link black dim">
+                {{ .Title }}
+              </a>
+            </h1>
+            <div class="nested-links f5 lh-copy nested-copy-line-height">
+              {{ .Summary }}
             </div>
+            <a href="{{.RelPermalink}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
           </div>
-        {{ end }}
+        </div>
       {{ end }}
     </section>
   </article>


### PR DESCRIPTION
This commit removes the filter that was previously showing only 'longread' articles on the homepage. Now, all posts from the 'posts' section, including newsletters, will be displayed.

This change was made based on user feedback to show all content, not just a specific type.