### PR TITLE
feat: Sort posts by date and improve cron job logic

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -21,24 +21,31 @@ on:
         default: false
 
 jobs:
-  # JOB 1: Genereer alle content en data bestanden
-  generate-content:
+  # JOB 1: Controleer of de workflow moet worden uitgevoerd (alleen op even weken)
+  check_week:
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.skip_content_generation != 'true')
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
     steps:
       - name: Check if week is even
-        if: github.event_name == 'schedule'
+        id: check
         run: |
-          week_number=$(date +%V)
-          if [ $((week_number % 2)) -ne 0 ]; then
-            echo "Skipping on odd week number: $week_number"
-            # Use exit code 78 to gracefully skip the job
-            exit 78
+          if [ $(( $(date +%V) % 2 )) -eq 0 ]; then
+            echo "Running on even week number: $(date +%V)"
+            echo "should_run=true" >> $GITHUB_OUTPUT
           else
-            echo "Running on even week number: $week_number"
+            echo "Skipping on odd week number: $(date +%V)"
+            echo "should_run=false" >> $GITHUB_OUTPUT
           fi
+
+  # JOB 2: Genereer alle content en data bestanden
+  generate-content:
+    runs-on: ubuntu-latest
+    needs: check_week
+    if: |
+      (github.event_name == 'schedule' && needs.check_week.outputs.should_run == 'true') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.skip_content_generation != 'true')
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up Python

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,7 +4,7 @@
       {{- .Content -}}
     </section>
     <section class="flex-ns flex-wrap justify-around mt5">
-      {{ range where .Site.RegularPages "Section" "posts" }}
+      {{ range (where .Site.RegularPages "Section" "posts").ByDate.Reverse }}
         <div class="relative w-100 w-30-l mb4 bg-white">
           <div class="bg-white mb3 pa4 gray overflow-hidden">
             {{with .CurrentSection.Title }}<span class="f6 db">{{ . }}</span>{{end}}


### PR DESCRIPTION
This commit addresses two separate issues:

1.  **Sort posts chronologically:** The posts on the homepage were not explicitly sorted, leading to a seemingly random order. The `layouts/index.html` template has been updated to sort posts by date in descending order, ensuring the newest posts always appear first.

2.  **Improve cron job skipping logic:** The weekly GitHub Actions workflow was using `exit 78` to skip execution on odd-numbered weeks. This caused the job to be marked as "failed", which was confusing. The workflow has been refactored to use a two-job approach. A new `check_week` job determines if the main `generate-content` job should run, allowing it to be gracefully skipped without reporting an error.