### PR TITLE
feat: Truncate post summaries to 50 words

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,7 +14,7 @@
               </a>
             </h1>
             <div class="nested-links f5 lh-copy nested-copy-line-height">
-              {{ .Summary }}
+              {{ .Summary | truncate 50 }}
             </div>
             <a href="{{.RelPermalink}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
           </div>


### PR DESCRIPTION
This change truncates the post summaries on the homepage to a maximum of 50 words. This ensures a more consistent and visually appealing layout, preventing long previews from dominating the page.