### PR TITLE
feat: Update summary truncation to 77 words

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,7 +14,7 @@
               </a>
             </h1>
             <div class="nested-links f5 lh-copy nested-copy-line-height">
-              {{ .Summary | truncate 50 }}
+              {{ .Summary | truncate 77 }}
             </div>
             <a href="{{.RelPermalink}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
           </div>


### PR DESCRIPTION
This change updates the post summary truncation on the homepage from 50 to 77 words, as requested by the user. This will continue to provide a consistent layout while allowing for slightly longer previews.