### PR TITLE
feat: Add Longreads and Newsletters sections to homepage

### DIFF
--- a/content/longreads/_index.md
+++ b/content/longreads/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Longreads"
+---

--- a/content/newsletters/_index.md
+++ b/content/newsletters/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Newsletters"
+---

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,7 +7,7 @@ defaultContentLanguage = "en"
   pagerSize = 20
   
 [params]
-  mainSections = ["posts"]
+  mainSections = ["posts", "longreads", "newsletters"]
   
 [outputs]
   home = ["HTML", "RSS"]
@@ -26,3 +26,13 @@ defaultContentLanguage = "en"
   name = "About"
   url = "/about/"
   weight = 2
+
+[[menu.main]]
+  name = "Longreads"
+  url = "/longreads/"
+  weight = 3
+
+[[menu.main]]
+  name = "Newsletters"
+  url = "/newsletters/"
+  weight = 4

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,6 +4,51 @@
       {{- .Content -}}
     </section>
     <section class="flex-ns flex-wrap justify-around mt5">
+      <div class="w-100">
+        <h2 class="f2">Longreads</h2>
+      </div>
+      {{ range (where .Site.RegularPages "Section" "longreads").ByDate.Reverse }}
+        <div class="relative w-100 w-30-l mb4 bg-white">
+          <div class="bg-white mb3 pa4 gray overflow-hidden">
+            {{with .CurrentSection.Title }}<span class="f6 db">{{ . }}</span>{{end}}
+            <h1 class="f3 near-black">
+              <a href="{{ .RelPermalink }}" class="link black dim">
+                {{ .Title }}
+              </a>
+            </h1>
+            <div class="nested-links f5 lh-copy nested-copy-line-height">
+              {{ .Summary }}
+            </div>
+            <a href="{{.RelPermalink}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
+          </div>
+        </div>
+      {{ end }}
+    </section>
+    <section class="flex-ns flex-wrap justify-around mt5">
+      <div class="w-100">
+        <h2 class="f2">Newsletters</h2>
+      </div>
+      {{ range (where .Site.RegularPages "Section" "newsletters").ByDate.Reverse }}
+        <div class="relative w-100 w-30-l mb4 bg-white">
+          <div class="bg-white mb3 pa4 gray overflow-hidden">
+            {{with .CurrentSection.Title }}<span class="f6 db">{{ . }}</span>{{end}}
+            <h1 class="f3 near-black">
+              <a href="{{ .RelPermalink }}" class="link black dim">
+                {{ .Title }}
+              </a>
+            </h1>
+            <div class="nested-links f5 lh-copy nested-copy-line-height">
+              {{ .Summary }}
+            </div>
+            <a href="{{.RelPermalink}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
+          </div>
+        </div>
+      {{ end }}
+    </section>
+    <section class="flex-ns flex-wrap justify-around mt5">
+      <div class="w-100">
+        <h2 class="f2">Posts</h2>
+      </div>
       {{ range (where .Site.RegularPages "Section" "posts").ByDate.Reverse }}
         <div class="relative w-100 w-30-l mb4 bg-white">
           <div class="bg-white mb3 pa4 gray overflow-hidden">


### PR DESCRIPTION
This commit adds two new sections to the homepage for "longreads" and "newsletters".

The following changes were made:
- Created `content/longreads` and `content/newsletters` directories.
- Added `_index.md` files to the new directories to define them as Hugo sections.
- Updated `hugo.toml` to include the new sections in `mainSections` and to add them to the main menu.
- Modified `layouts/index.html` to display the content from the new sections on the homepage, alongside the existing "posts" section.