### PR TITLE
feat: Add longreads and newsletters sections

### DIFF
--- a/content/longreads/longread_2025-09-08_en.md
+++ b/content/longreads/longread_2025-09-08_en.md
@@ -1,66 +1,57 @@
 ---
-title: "Dairy Reimagined: Nestle, Perfect Day, and the Future of Food"
+title: "Fashion's New Skin: How Mushroom Leather is Revolutionizing Style"
 date: 2025-09-08
 ---
 
-# Dairy Reimagined: Nestle, Perfect Day, and the Future of Food
+# Fashion's New Skin: How Mushroom Leather is Revolutionizing Style
 
-Nestle's groundbreaking partnership with Perfect Day is more than just a new product line; it's a signal that the dairy industry is on the cusp of a profound transformation. This collaboration hints at a future where animal-free dairy alternatives, crafted through innovative technology, move from niche novelty to everyday staple, reshaping our understanding of what dairy can be.
+**Introduction:**
 
-## Section 1: The Dawn of Precision-Fermented Dairy: Introducing Perfect Day and its Technology
+Imagine a world where fashion is both stylish and sustainable, where the materials we wear don't harm the planet. This future is closer than you think, thanks to a revolutionary material called mycelium leather, also known as mushroom leather. Forget the harsh chemicals and ethical concerns associated with traditional leather production; mycelium offers a cruelty-free, eco-friendly alternative that's poised to reshape the fashion industry. Get ready to explore the fascinating world of this innovative material and discover how it's paving the way for a more sustainable and stylish future.
 
-Precision fermentation is the engine driving this potential revolution. At its core, it involves using microorganisms, like fungi or yeast, as tiny factories. These microorganisms are genetically engineered to produce specific proteins, in this case, the very same whey and casein proteins found in cow's milk. This process eliminates the need for animals entirely. Perfect Day has pioneered this technology, creating animal-free dairy proteins with the same taste, texture, and nutritional properties as their traditional counterparts.
+**## What is Mycelium Leather?**
 
-Perfect Day's technology offers a compelling suite of advantages. From a sustainability perspective, it drastically reduces the environmental footprint associated with traditional dairy farming. Land use, greenhouse gas emissions, and water consumption are all significantly lower. Ethically, it addresses concerns surrounding animal welfare, providing a dairy option that aligns with vegetarian and vegan principles without compromising on taste or nutrition.
+Mycelium leather isn't actually made from mushrooms themselves, but from mycelium – the root structure of fungi. Think of it as the vast, interwoven network of thread-like filaments that grow underground, connecting mushrooms. This network is incredibly versatile and can be grown in controlled environments using agricultural waste as a nutrient source.
 
-Nestle's foray into precision fermentation reflects a broader commitment to exploring alternative protein sources and developing sustainable food solutions. Recognizing the growing consumer demand for environmentally friendly and ethically produced products, Nestle is actively investing in innovative technologies like Perfect Day's.
+The process involves cultivating mycelium on a substrate like sawdust or hemp. As the mycelium grows, it forms a dense mat. This mat is then harvested, processed, and treated to create a material that mimics the look and feel of traditional leather. The specific properties of the resulting mycelium leather can be tailored by varying the type of fungus used, the growth conditions, and the post-processing techniques. This allows for a wide range of textures, thicknesses, and finishes, making it suitable for various applications.
 
-The Nestle-Perfect Day partnership is focused on developing a range of animal-free dairy products, including ice cream, milk, and potentially cheese alternatives. While specific product details remain under wraps, the initial target markets are likely to be regions with a strong consumer interest in sustainable and alternative food options, such as the United States and Europe. The partnership aims to provide consumers with familiar dairy products, but with a significantly reduced environmental impact.
+**## The Environmental Benefits of Mycelium Leather**
 
-## Section 2: Consumer Perception and Acceptance: Will Consumers Embrace Animal-Free Dairy?
+The environmental advantages of mycelium leather are significant and contribute to its growing popularity. Compared to traditional leather production, which relies on environmentally damaging processes like tanning with chromium, mycelium leather offers a much cleaner alternative.
 
-Consumer attitudes towards dairy are complex. While traditional dairy remains a dietary staple for many, plant-based alternatives have gained significant traction, driven by health concerns, ethical considerations, and environmental awareness. However, plant-based options often fall short in replicating the taste, texture, and nutritional profile of traditional dairy, leaving a gap in the market.
+*   **Reduced Water Consumption:** Traditional leather tanning requires vast amounts of water, often polluting local waterways with harmful chemicals. Mycelium leather production uses significantly less water.
+*   **Lower Carbon Footprint:** The cultivation of mycelium can be carbon neutral or even carbon negative, as it can utilize agricultural waste as a feedstock. This reduces the reliance on resource-intensive processes and lowers greenhouse gas emissions.
+*   **Biodegradability:** Depending on the specific processing methods, mycelium leather can be biodegradable, meaning it will decompose naturally at the end of its life cycle, reducing landfill waste.
+*   **Reduced Land Use:** Raising livestock for leather production requires vast areas of land for grazing. Mycelium can be grown vertically in controlled environments, minimizing land use.
+*   **Elimination of Harmful Chemicals:** Mycelium leather production avoids the use of toxic chemicals like chromium, formaldehyde, and heavy metals, which are commonly used in traditional leather tanning.
 
-Precision-fermented dairy holds the potential to bridge this gap. Because it uses the same proteins as cow's milk, it offers a sensory experience virtually indistinguishable from traditional dairy. This could attract consumers who are hesitant to compromise on taste and texture but are open to more sustainable and ethical options.
+**## The Properties and Applications of Mycelium Leather**
 
-However, consumer concerns about GMOs, safety, labeling, and transparency are crucial to address. Many consumers are wary of genetically modified organisms, even though the proteins produced through precision fermentation are molecularly identical to those found in cow's milk. Clear and transparent labeling is essential to inform consumers about the production process and ingredients. Rigorous safety testing and regulatory approval are also crucial to build trust.
+Mycelium leather boasts a range of desirable properties that make it a viable alternative to traditional leather and other synthetic materials.
 
-Strategies for building consumer trust include emphasizing the environmental benefits, highlighting the ethical considerations, and providing transparent information about the production process. Marketing and education play a vital role in shaping consumer perception. By framing precision-fermented dairy as a sustainable and ethical alternative that delivers the same taste and nutritional benefits as traditional dairy, companies can encourage wider acceptance. Honest communication about the technology and addressing consumer concerns head-on are essential for building long-term trust.
+*   **Durability:** Mycelium leather can be engineered to be strong and durable, making it suitable for applications that require resilience.
+*   **Flexibility:** The material is flexible and can be molded into various shapes, making it ideal for clothing, footwear, and accessories.
+*   **Water Resistance:** While not naturally waterproof, mycelium leather can be treated to enhance its water resistance.
+*   **Texture and Appearance:** Mycelium leather can be customized to mimic the look and feel of different types of leather, from smooth and supple to textured and rugged.
+*   **Breathability:** Mycelium leather can be more breathable than some synthetic alternatives, making it more comfortable to wear.
 
-## Section 3: Market Disruption: How Will Precision Fermentation Impact the Dairy Industry?
+These properties allow mycelium leather to be used in a wide range of applications, including:
 
-The potential market share that precision-fermented dairy could capture is substantial. As consumers become increasingly aware of the environmental and ethical implications of traditional dairy farming, the demand for sustainable alternatives is likely to grow. If precision fermentation can deliver a product that is indistinguishable from traditional dairy in terms of taste and texture, it could capture a significant portion of the market currently held by traditional dairy and plant-based alternatives.
+*   **Fashion:** Clothing, shoes, handbags, wallets, belts, and other accessories.
+*   **Furniture:** Upholstery for chairs, sofas, and other furniture pieces.
+*   **Automotive:** Seat covers, dashboards, and other interior components.
+*   **Packaging:** Sustainable packaging materials for various products.
 
-The competitive landscape will undoubtedly shift. Traditional dairy companies may respond in several ways: investing in their own precision fermentation technologies, acquiring companies like Perfect Day, or focusing on promoting the perceived benefits of traditional dairy farming. Some may resist the change, while others may adapt and embrace the new technology.
+**## Brands Embracing Mycelium Leather**
 
-The impact on pricing and affordability remains to be seen. Currently, precision-fermented dairy is more expensive to produce than traditional dairy. However, as production scales up and technology improves, costs are expected to decrease, potentially making precision-fermented dairy more competitive in the long run.
+Several forward-thinking brands are already incorporating mycelium leather into their products, demonstrating its growing acceptance and potential. Major luxury brands such as Hermès have partnered with companies like MycoWorks to create products like the Victoria bag made from Fine Mycelium. Other brands, including Adidas, Stella McCartney, and Lululemon, are exploring the use of mycelium leather in footwear and apparel. These collaborations not only showcase the versatility of the material but also help to raise awareness and drive demand for sustainable alternatives. The commitment of these high-profile brands signals a significant shift in the fashion industry towards more environmentally conscious practices.
 
-The winners in this evolving market will be those who can innovate, adapt, and meet the changing demands of consumers. Companies that embrace sustainable practices, invest in new technologies, and build strong brands are likely to thrive. Those who resist change or fail to address consumer concerns may struggle.
+**## Challenges and Future Directions**
 
-Venture capital and investment are playing a crucial role in accelerating the growth of precision fermentation. Investors are recognizing the potential of this technology to disrupt the dairy industry and address global sustainability challenges. This influx of capital is fueling research and development, scaling up production, and driving innovation.
+Despite its promise, mycelium leather faces some challenges. Scaling up production to meet the demands of the global fashion industry is a significant hurdle. The cost of production is currently higher than traditional leather, which may limit its widespread adoption. Further research and development are needed to improve the material's performance, durability, and water resistance.
 
-## Section 4: The Impact on Traditional Dairy Farming: A Sustainable Future or Economic Threat?
+However, the future of mycelium leather is bright. As production processes become more efficient and economies of scale are achieved, the cost is expected to decrease. Ongoing research is focused on enhancing the material's properties and expanding its range of applications. With continued innovation and investment, mycelium leather has the potential to become a mainstream material, transforming the fashion industry and contributing to a more sustainable future.
 
-The potential economic consequences for dairy farmers and rural communities are significant and require careful consideration. A widespread shift towards precision-fermented dairy could lead to a decline in demand for cow's milk, potentially impacting dairy farmers' livelihoods and the economies of rural communities that rely on dairy farming.
+**Conclusion:**
 
-However, it's important to consider the environmental impact of traditional dairy farming. Land use, greenhouse gas emissions, and water consumption associated with dairy production are substantial. Precision fermentation offers a more sustainable alternative with a significantly smaller environmental footprint.
-
-A just transition for dairy farmers is essential. This could include diversification into other agricultural sectors, retraining programs to equip farmers with new skills, and government support to help farmers adapt to the changing market. Exploring the possibility of integrating precision fermentation into existing dairy farming operations is another avenue to consider, potentially allowing farmers to leverage their existing infrastructure and expertise.
-
-Government policies and regulations will play a crucial role in shaping the future of dairy farming. Incentives for sustainable practices, regulations on greenhouse gas emissions, and support for farmers transitioning to new technologies can all help to create a more sustainable and equitable dairy industry.
-
-## Section 5: Scaling Up and Overcoming Challenges: The Path to Mainstream Adoption
-
-Scaling up precision fermentation production to meet mainstream demand is a significant challenge. Building the necessary infrastructure, optimizing production processes, and ensuring consistent product quality are all crucial for achieving widespread adoption.
-
-Regulatory hurdles and ensuring food safety standards are also essential. Precision fermentation products must undergo rigorous safety testing and comply with all relevant regulations before they can be sold to consumers. Clear and transparent regulatory frameworks are needed to ensure consumer safety and build public trust.
-
-The cost-effectiveness of precision fermentation compared to traditional dairy production is another key factor. While costs are currently higher, ongoing innovation and economies of scale are expected to drive costs down, making precision-fermented dairy more competitive in the long run.
-
-Innovation in precision fermentation technology can further improve efficiency and sustainability. Research and development efforts are focused on optimizing the fermentation process, improving the efficiency of protein production, and reducing the environmental footprint of the technology.
-
-Collaboration and partnerships are essential for driving the mainstream adoption of precision-fermented dairy. Working together, companies, researchers, and policymakers can overcome challenges, accelerate innovation, and build a more sustainable and resilient food system.
-
-## Conclusion Summary:
-
-The Nestle-Perfect Day collaboration represents a pivotal moment in the food industry, signaling a significant shift towards the mainstream acceptance of precision-fermented dairy. This partnership has the potential to reshape consumer choices, alter market dynamics, and redefine the future of traditional dairy farming. While challenges remain in scaling production, addressing consumer concerns, and navigating regulatory landscapes, the potential benefits of precision fermentation – including improved sustainability, ethical considerations, and the ability to create dairy products that are virtually indistinguishable from traditional ones – are undeniable. The journey towards a dairy industry reimagined is underway, and the Nestle-Perfect Day partnership is at the forefront of this transformative movement.
+Mycelium leather represents a paradigm shift in the world of fashion and materials science. Its eco-friendly production, versatile properties, and growing adoption by leading brands make it a compelling alternative to traditional leather. While challenges remain, the potential benefits for the environment and the fashion industry are undeniable. As we move towards a more sustainable future, mycelium leather is poised to play a significant role in shaping the way we dress, decorate our homes, and interact with the world around us. It's not just a trend; it's a revolution, growing from the ground up.

--- a/content/longreads/longread_2025-09-08_nl.md
+++ b/content/longreads/longread_2025-09-08_nl.md
@@ -1,66 +1,44 @@
 ---
-title: "Zuivel Heruitgevonden: Nestle en Perfect Day Bouwen aan een Dierproefvrije Toekomst"
+title: "Myceliumleer: De Toekomst van Duurzame Mode"
 date: 2025-09-08
 ---
 
-# Zuivel Heruitgevonden: Nestle en Perfect Day Bouwen aan een Dierproefvrije Toekomst
+# Myceliumleer: De Toekomst van Duurzame Mode
 
-Nestle's recente samenwerking met Perfect Day markeert een potentieel keerpunt in de zuivelindustrie. Het opent de deur naar een toekomst waarin dierproefvrije zuivelalternatieven niet langer een nicheproduct zijn, maar een volwaardige, breed geaccepteerde optie voor consumenten. Deze innovatieve benadering, gebaseerd op precisiefermentatie, belooft een duurzamere en ethisch verantwoorde manier om te genieten van de smaak en voedingswaarde van zuivel, zonder de nadelen van traditionele veeteelt.
+Stel je voor: een materiaal dat sterk, flexibel en waterafstotend is, en bovendien groeit in plaats van wordt geproduceerd. Een materiaal dat een duurzaam alternatief biedt voor leer en synthetische stoffen, en de potentie heeft om de mode-industrie radicaal te veranderen. Dit is geen sciencefiction, maar de realiteit van schimmelleer, ook wel myceliumleer genoemd. Deze innovatieve stof, gemaakt van de wortelstructuur van paddenstoelen, wint snel aan populariteit en wordt gezien als de toekomst van duurzame mode. Maar wat maakt myceliumleer zo bijzonder, en hoe kan het de mode-industrie transformeren?
 
-## Sectie 1: Het Begin van Precisiefermenteerde Zuivel: Perfect Day en zijn Technologie
+## Wat is Myceliumleer Eigenlijk?
 
-Precisiefermentatie is een geavanceerd biotechnologisch proces waarbij micro-organismen, zoals gist of schimmels, worden gebruikt om specifieke eiwitten te produceren. In het geval van Perfect Day worden deze micro-organismen genetisch gemodificeerd om wei- en caseïne-eiwitten te produceren, de belangrijkste eiwitten in melk. Dit gebeurt in fermentatietanks, vergelijkbaar met het brouwen van bier. Het resultaat is een dierproefvrij zuivelproduct dat identiek is aan traditionele zuivel op moleculair niveau.
+Schimmelleer, of myceliumleer, is een materiaal dat wordt gekweekt uit het mycelium van paddenstoelen. Mycelium is het wortelstelsel van een paddenstoel, een netwerk van fijne draden dat zich onder de grond of in ander organisch materiaal bevindt. In tegenstelling tot traditioneel leer, dat afkomstig is van dierenhuiden en een intensief productieproces vereist, wordt schimmelleer gekweekt in een laboratoriumomgeving.
 
-Perfect Day's technologie biedt aanzienlijke voordelen. Het is duurzamer omdat het minder land, water en energie verbruikt dan traditionele melkveehouderij, wat leidt tot een lagere CO2-voetafdruk. Bovendien elimineert het ethische bezwaren die vaak worden geuit over de behandeling van dieren in de zuivelindustrie.
+Het proces begint met het selecteren van een geschikte paddenstoelsoort. Vervolgens wordt het mycelium van deze paddenstoel gekweekt op een substraat, zoals zaagsel of landbouwafval. Onder gecontroleerde omstandigheden van temperatuur en vochtigheid groeit het mycelium en vormt het een dicht netwerk. Wanneer het mycelium de gewenste dikte heeft bereikt, wordt het geoogst en behandeld.
 
-Nestle's interesse in alternatieve eiwitbronnen en duurzame voedseloplossingen is duidelijk. Het bedrijf heeft zich gecommitteerd aan het verminderen van zijn milieu-impact en het aanbieden van een breder scala aan voedingsopties voor consumenten. De samenwerking met Perfect Day is een logische stap in deze richting.
+De behandeling van het geoogste mycelium is cruciaal voor de uiteindelijke eigenschappen van het schimmelleer. Door het mycelium te persen, drogen en eventueel te behandelen met natuurlijke kleurstoffen en coatings, kan de textuur, sterkte en waterbestendigheid worden aangepast. Het resultaat is een materiaal dat qua uiterlijk en gevoel vergelijkbaar is met leer, maar met een veel kleinere ecologische voetafdruk.
 
-De details van de Nestle-Perfect Day partnerschap zijn nog niet volledig openbaar, maar het is bekend dat ze werken aan de ontwikkeling van een reeks dierproefvrije zuivelproducten, waaronder ijs en roomkaas. De initiële doelmarkten zijn waarschijnlijk de Verenigde Staten en andere landen waar de vraag naar duurzame en ethische voedselopties groeit.
+## De Voordelen van Myceliumleer boven Traditioneel Leer
 
-## Sectie 2: Consumentenperceptie en Acceptatie: Staan Consumenten Open voor Dierproefvrije Zuivel?
+De voordelen van myceliumleer ten opzichte van traditioneel leer zijn aanzienlijk. Ten eerste is de productie van schimmelleer veel duurzamer. Het vereist minder water, energie en land dan de veeteelt die nodig is voor de leerproductie. Bovendien produceert het geen schadelijke afvalstoffen zoals chroom, dat vaak wordt gebruikt bij het looien van leer.
 
-De huidige consumentenattitude ten opzichte van traditionele zuivel varieert sterk. Sommigen blijven trouw aan traditionele producten, terwijl anderen zich wenden tot plantaardige alternatieven vanwege gezondheids-, milieu- of ethische redenen. Plantaardige alternatieven, zoals soja-, amandel- en havermelk, hebben echter vaak een andere smaak en textuur dan traditionele zuivel, wat voor sommige consumenten een drempel kan vormen.
+Ten tweede is myceliumleer een diervriendelijk alternatief. Er worden geen dieren gedood of uitgebuit bij de productie ervan. Dit maakt het een aantrekkelijke optie voor consumenten die waarde hechten aan dierenwelzijn.
 
-Precisiefermenteerde zuivel heeft het potentieel om een breder publiek aan te spreken. Omdat het dezelfde eiwitten bevat als traditionele zuivel, biedt het een vergelijkbare smaak, textuur en voedingsprofiel. Dit kan het aantrekkelijker maken voor consumenten die op zoek zijn naar een duurzaam alternatief zonder concessies te doen aan de smaak.
+Ten derde is myceliumleer biologisch afbreekbaar. Aan het einde van de levensduur kan het materiaal worden gecomposteerd, waardoor er geen schadelijke stoffen in het milieu terechtkomen.
 
-Er zijn echter ook potentiële consumentenbezwaren. Sommigen kunnen zich zorgen maken over het gebruik van genetische modificatie, de veiligheid van het proces, of de etikettering van de producten. Transparantie is cruciaal om deze zorgen weg te nemen. Consumenten moeten volledig worden geïnformeerd over het productieproces en de veiligheid van de producten.
+Ten vierde biedt de kweek van myceliumleer een snellere productiecyclus dan traditionele leerproductie. Waar het jaren kan duren om een koe groot te brengen voor haar huid, kan myceliumleer in enkele weken worden gekweekt. Dit maakt het een potentiële oplossing voor de groeiende vraag naar duurzame materialen in de mode-industrie.
 
-Strategieën voor het opbouwen van consumentenvertrouwen omvatten duidelijke etikettering, open communicatie over het productieproces en onafhankelijke veiligheidstests. Marketing en educatie spelen een belangrijke rol bij het vormgeven van de consumentenperceptie. Het benadrukken van de duurzaamheid, de ethische voordelen en de vergelijkbare smaak en textuur kan consumenten overtuigen om precisiefermenteerde zuivel te proberen.
+## Toepassingen van Myceliumleer in de Mode-industrie
 
-## Sectie 3: Marktverstoring: Welke Impact Heeft Precisiefermentatie op de Zuivelindustrie?
+Myceliumleer kent een breed scala aan toepassingen in de mode-industrie. Het kan worden gebruikt voor het maken van kleding, schoenen, tassen, accessoires en zelfs meubels. Verschillende designers en merken hebben al geëxperimenteerd met myceliumleer en hebben succesvolle collecties gelanceerd.
 
-Precisiefermenteerde zuivel heeft het potentieel om een aanzienlijk marktaandeel te veroveren, vooral in segmenten waar consumenten bereid zijn meer te betalen voor duurzame en ethische producten. De exacte omvang van het marktaandeel zal afhangen van de prijs, de beschikbaarheid en de consumentenacceptatie.
+Zo zijn er bijvoorbeeld schoenen gemaakt van myceliumleer die net zo comfortabel en duurzaam zijn als leren schoenen. Ook tassen van myceliumleer zijn een populaire keuze, omdat ze stijlvol, sterk en milieuvriendelijk zijn. Daarnaast wordt myceliumleer gebruikt voor het maken van jassen, riemen en andere accessoires.
 
-Traditionele zuivelbedrijven zullen waarschijnlijk op verschillende manieren reageren. Sommigen zullen de concurrentie aangaan door zelf te investeren in precisiefermentatie, terwijl anderen zullen proberen hun traditionele melkveehouderij te verduurzamen. Sommige bedrijven zullen mogelijk proberen de opkomst van precisiefermenteerde zuivel te blokkeren door middel van lobbywerk en desinformatiecampagnes.
+De mogelijkheden van myceliumleer zijn eindeloos. Naarmate de technologie zich verder ontwikkelt, zullen er steeds meer toepassingen worden ontdekt. Het is dan ook te verwachten dat myceliumleer in de toekomst een steeds grotere rol zal spelen in de mode-industrie.
 
-De impact op de prijzen en de betaalbaarheid van zuivelproducten is nog onzeker. In de beginfase zullen precisiefermenteerde producten waarschijnlijk duurder zijn dan traditionele zuivel, maar naarmate de productie opschaalt en de kosten dalen, kunnen ze concurrerender worden.
+## Uitdagingen en Toekomstperspectief
 
-Potentiële winnaars in de evoluerende zuivelmarkt zijn bedrijven die snel inspelen op de veranderende consumentenvoorkeuren en investeren in innovatieve technologieën. Verliezers kunnen traditionele zuivelbedrijven zijn die vasthouden aan oude methoden en niet in staat zijn om zich aan te passen aan de nieuwe realiteit.
+Ondanks de vele voordelen zijn er ook nog enkele uitdagingen die overwonnen moeten worden voordat myceliumleer op grote schaal kan worden toegepast. Een van de belangrijkste uitdagingen is de schaalbaarheid van de productie. Het kweken van myceliumleer is nog relatief nieuw en de productiecapaciteit is nog niet voldoende om aan de grote vraag van de mode-industrie te voldoen.
 
-Venture capital en investeringen spelen een cruciale rol bij het versnellen van de groei van precisiefermentatie. Start-ups en bedrijven die actief zijn in deze sector trekken steeds meer investeringen aan, wat de verdere ontwikkeling en opschaling van de technologie mogelijk maakt.
+Daarnaast is de prijs van myceliumleer momenteel nog hoger dan die van traditioneel leer. Dit komt doordat de productieprocessen nog in ontwikkeling zijn en er nog geen sprake is van massaproductie. Naarmate de technologie zich verder ontwikkelt en de productie wordt opgeschaald, zal de prijs naar verwachting dalen.
 
-## Sectie 4: De Impact op Traditionele Melkveehouderij: Een Duurzame Toekomst of Economische Bedreiging?
+Ondanks deze uitdagingen is het toekomstperspectief van myceliumleer rooskleurig. Er wordt volop geïnvesteerd in onderzoek en ontwikkeling om de productieprocessen te verbeteren en de eigenschappen van het materiaal verder te optimaliseren. Het is dan ook te verwachten dat myceliumleer in de komende jaren een steeds belangrijkere rol zal spelen in de mode-industrie en zal bijdragen aan een meer duurzame en diervriendelijke toekomst.
 
-De opkomst van precisiefermenteerde zuivel kan aanzienlijke economische gevolgen hebben voor melkveehouders en landelijke gemeenschappen. Als de vraag naar traditionele melk afneemt, kunnen melkveehouders te maken krijgen met lagere prijzen en verminderde inkomsten. Dit kan leiden tot het sluiten van boerderijen en het verlies van banen in de agrarische sector.
-
-De milieu-impact van traditionele melkveehouderij is aanzienlijk. Melkveebedrijven zijn verantwoordelijk voor een aanzienlijk deel van de uitstoot van broeikasgassen, het landgebruik en het waterverbruik. Precisiefermentatie biedt een duurzamer alternatief met een lagere milieu-impact.
-
-Er zijn strategieën nodig voor een rechtvaardige transitie voor melkveehouders, waaronder diversificatie en omscholingsprogramma's. Melkveehouders kunnen bijvoorbeeld worden getraind om andere gewassen te verbouwen, te werken in de hernieuwbare energiesector of te profiteren van de groeiende vraag naar duurzame landbouwpraktijken.
-
-Overheidsbeleid en -regelgeving spelen een belangrijke rol bij het vormgeven van de toekomst van de melkveehouderij. Overheden kunnen subsidies verstrekken voor duurzame landbouwpraktijken, investeren in omscholingsprogramma's en regelgeving implementeren om de milieu-impact van de melkveehouderij te verminderen.
-
-Het is ook mogelijk om precisiefermentatie te integreren in bestaande melkveebedrijven. Melkveehouders kunnen bijvoorbeeld micro-organismen kweken die vervolgens worden gebruikt om zuivelproducten te produceren. Dit kan melkveehouders helpen om hun inkomsten te diversifiëren en te profiteren van de groeiende vraag naar duurzame zuivelalternatieven.
-
-## Sectie 5: Opschalen en Uitdagingen Overwinnen: De Weg naar Algemene Acceptatie
-
-Een van de grootste uitdagingen is het opschalen van de precisiefermentatieproductie om aan de mainstream vraag te voldoen. Dit vereist aanzienlijke investeringen in productiecapaciteit en het optimaliseren van het fermentatieproces om de efficiëntie te maximaliseren en de kosten te verlagen.
-
-Regelgevende hindernissen moeten worden overwonnen en voedselveiligheidsnormen moeten worden gewaarborgd. De regelgeving rond genetisch gemodificeerde organismen (GGO's) kan complex en verschillend zijn in verschillende landen. Het is belangrijk om samen te werken met regelgevende instanties om duidelijke en transparante regels vast te stellen voor de productie en etikettering van precisiefermenteerde zuivelproducten.
-
-De kosteneffectiviteit van precisiefermentatie in vergelijking met traditionele melkproductie is een belangrijke factor voor de algemene acceptatie. Naarmate de productie opschaalt en de technologie verbetert, zullen de kosten waarschijnlijk dalen, waardoor precisiefermenteerde zuivel concurrerender wordt.
-
-Innovatie in precisiefermentatietechnologie is essentieel om de efficiëntie en duurzaamheid verder te verbeteren. Onderzoek en ontwikkeling zijn nodig om de fermentatieprocessen te optimaliseren, nieuwe micro-organismen te ontwikkelen en de kosten te verlagen.
-
-Samenwerking en partnerschappen spelen een cruciale rol bij het stimuleren van de mainstream acceptatie van precisiefermenteerde zuivel. Samenwerking tussen bedrijven, onderzoeksinstituten en overheidsinstanties kan helpen om de technologie te ontwikkelen, de productie op te schalen en consumenten te informeren.
-
-De samenwerking tussen Nestle en Perfect Day vertegenwoordigt een belangrijke stap in de richting van de brede acceptatie van precisiefermenteerde zuivel. Hoewel uitdagingen blijven bestaan op het gebied van productie-opschaling en het aanpakken van consumentenbezwaren, heeft deze innovatieve technologie het potentieel om de consumentenkeuze, de marktdynamiek en de toekomst van de traditionele melkveehouderij ingrijpend te veranderen.
+Myceliumleer vertegenwoordigt meer dan alleen een nieuw materiaal; het is een paradigmaverschuiving in de manier waarop we over mode denken. Door de principes van duurzaamheid, innovatie en respect voor het milieu te omarmen, kan schimmelleer de mode-industrie transformeren en een nieuw tijdperk van verantwoorde consumptie inluiden. Het is een materiaal met potentie, een materiaal met een toekomst, en een materiaal dat de wereld kan veranderen.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -46,9 +46,6 @@
       {{ end }}
     </section>
     <section class="flex-ns flex-wrap justify-around mt5">
-      <div class="w-100">
-        <h2 class="f2">Posts</h2>
-      </div>
       {{ range (where .Site.RegularPages "Section" "posts").ByDate.Reverse }}
         <div class="relative w-100 w-30-l mb4 bg-white">
           <div class="bg-white mb3 pa4 gray overflow-hidden">


### PR DESCRIPTION
This commit introduces two new sections to the website: "longreads" and "newsletters".

It performs the following changes:
- Creates new directories `content/longreads` and `content/newsletters`.
- Moves all existing longread and newsletter content into these new directories.
- Updates the Hugo configuration (`hugo.toml`) to recognize and display these new sections in the menu.
- Modifies the homepage layout (`layouts/index.html`) to render the new sections.
- Updates the content generation pipeline (`src/run_pipeline.py`) to save new content to the correct directories.
- Updates the archiving logic to handle the new content structure.