### PR TITLE
Fix: Corrigeer zoekpad voor nieuwsbrieven in select_topic

### DIFF
--- a/src/select_topic.py
+++ b/src/select_topic.py
@@ -7,12 +7,12 @@ def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 def get_latest_newsletter_file(content_dir="content"):
-    # Gebruik een glob patroon met ** voor recursief zoeken in alle submappen van posts.
-    search_path = os.path.join(content_dir, "posts", "**", "*_en.md")    
+    # Gebruik een glob patroon met ** voor recursief zoeken in alle submappen van newsletters.
+    search_path = os.path.join(content_dir, "newsletters", "**", "*_en.md")
     # Voeg de recursive=True vlag toe aan glob.glob
     list_of_files = glob.glob(search_path, recursive=True)
     if not list_of_files:
-        raise FileNotFoundError(f"Geen Engelse nieuwsbrief (*_en.md) gevonden in '{os.path.join(content_dir, 'posts')}'.")
+        raise FileNotFoundError(f"Geen Engelse nieuwsbrief (*_en.md) gevonden in '{os.path.join(content_dir, 'newsletters')}'.")
     return max(list_of_files, key=os.path.getctime)
 
 def select_best_topic(newsletter_content: str, previous_topics: list) -> str:


### PR DESCRIPTION
De 'Generate Long-Read Outline' stap in de pipeline faalde omdat het `select_topic.py` script zocht naar de Engelse nieuwsbrief in de `content/posts` map.

De pipeline slaat de nieuwsbrieven echter op in een subdirectory met timestamp binnen `content/newsletters`.

Deze wijziging past het zoekpad in `src/select_topic.py` aan om in de juiste `content/newsletters` map te zoeken, waardoor de fout wordt opgelost. Het bijbehorende foutbericht is ook bijgewerkt.