### PR TITLE
Fix: Correct path to generate_images.py in workflow

### DIFF
--- a/.github/workflows/2-generate-only.yml
+++ b/.github/workflows/2-generate-only.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Generate images for new content
         env:
           GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-        run: python generate_images.py
+        run: python pipeline/generate_images.py
 
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
Updates the `2-generate-only.yml` workflow to use the correct path for the `generate_images.py` script.

The previous command was `python generate_images.py`, which failed because the script is located in the `pipeline/` directory. The command has been corrected to `python pipeline/generate_images.py`.